### PR TITLE
minor cleanup for relating to credentials/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 Analyzing github PRs with PoC-grade Python code.
 
 ## Overiview
-Bare bones python code support analyzation of Github Pull Requests (PRs) via Github API.
+Bare bones python code supporting analyzation of Github Pull Requests (PRs) via Github API.
 For sample usage have a look at the `pullrx.cmd` package.

--- a/pullrx/github/client.py
+++ b/pullrx/github/client.py
@@ -39,7 +39,7 @@ class GithubClient(object):
     # https://developer.github.com/v3/
 
     def __init__(self, request_context=None):
-        self._context = request_context or RequestContext()
+        self._context = request_context or default_context()
 
     def _get(self, url, request_context, params=None):
         response = requests.get(url, params=params,

--- a/pullrx/github/creds.py
+++ b/pullrx/github/creds.py
@@ -30,3 +30,5 @@ def credentials_from_file_store(hostname, cred_file_path=DEFAULT_CRED_FILE, prot
                 if cred_host == hostname:
                     return Credentials(hostname, user_pass.split(':')[0],
                                        user_pass.split(':')[1], protocol=protocol)
+
+    raise PermissionError("No credentials found for %s//%s" % (protocol, hostname))


### PR DESCRIPTION
Minor changes:
- Use default_context() rather than a bare RequestContext() in
GithubClient constructor
- Raise a PermissionError in credentials_from_file_store() if creds
can't be found.
- Fix typo in README.md