### PR TITLE
calculate weekly pulls

### DIFF
--- a/pullrx/cmd/pull_requests.py
+++ b/pullrx/cmd/pull_requests.py
@@ -1,9 +1,17 @@
+import datetime
+import json
+import pytz
 import threading
+
+from dateutil import relativedelta
+from dateutil import parser
 
 from pullrx.github import client
 from pullrx.mr import collections
 from pullrx.store import mem
 
+
+# NOTE: this module is just a scratchpad / playground
 
 class PRListThread(threading.Thread):
 
@@ -21,6 +29,31 @@ class PRListThread(threading.Thread):
         pr_client = client.PullRequestClient(self._context)
         prs = pr_client.list(self._org, self._repo, params=self._params)
         self._store.set_keyed_path(self._key_path, prs)
+
+
+class OrgPRs(object):
+
+    def __init__(self, org_name, list_of_prs=None):
+        self.org_name = org_name
+        self.prs = list_of_prs or []
+
+    def default_file_name(self):
+        return "/tmp/%s_prs.json" % self.org_name
+
+    def save(self, file_name=None):
+        file_name = file_name or self.default_file_name()
+        with open(file_name, 'w') as f:
+            json.dump({
+                'org_name': self.org_name,
+                'pull_requests': self.prs
+            }, f)
+
+    def load(self, file_name=None):
+        file_name = file_name or self.default_file_name()
+        with open(file_name) as f:
+            data = json.load(f)
+            self.org_name = data['org_name']
+            self.prs = data['pull_requests']
 
 
 def org_repos(org_name):
@@ -50,6 +83,16 @@ def org_repos_with_prs(org_name):
     return named_repos
 
 
+def org_prs_to_file(org_name, file_name=None):
+    repos_with_prs = org_repos_with_prs(org_name)
+    org_prs = OrgPRs(org_name)
+    for repo_name, repo_data in repos_with_prs.items():
+        org_prs.prs.extend(repo_data['pull_requests'])
+
+    org_prs.save(file_name=file_name)
+    print("%s pull requests saved to %s" % (org_name, file_name or org_prs.default_file_name()))
+
+
 def print_org_repos_summary(org_name):
     repo_store = org_repos_with_prs(org_name)
     org_prs = collections.collect_dict_keys(['pull_requests'], *repo_store.values())
@@ -74,4 +117,93 @@ def print_org_repos_summary(org_name):
         print("---")
 
 
-print_org_repos_summary('ramda')
+def save_org_prs_to_file(org_name, file_name=None):
+    org_prs_to_file(org_name, file_name=file_name)
+
+
+def munk_with_time():
+    t1 = '2011-04-10T20:09:31Z'
+    t2 = '2011-04-10T20:09:31Z'
+    print(t1 < t2)
+
+    d1 = parser.parse(t1)
+    print("github fmt: %s" % d1)
+    now = datetime.datetime.utcnow()
+    last_week = now + relativedelta.relativedelta(weeks=-1)
+    print("now: %s" % now)
+    print("a week ago: %s" % last_week)
+
+
+def print_ramda_repo_summary():
+    print_org_repos_summary('ramda')
+
+
+def org_pull_requests_list(org_name, cache_file=None):
+    org_pulls = OrgPRs(org_name)
+    try:
+        org_pulls.load(file_name=cache_file)
+    except FileNotFoundError:
+        save_org_prs_to_file(org_name, file_name=cache_file)
+        org_pulls.load(file_name=cache_file)
+
+    return org_pulls.prs
+
+
+class WeeklyPulls(object):
+
+    def __init__(self, relative_day=relativedelta.MO):
+        self._relative_day = relative_day
+        self._weekly_pulls = {}
+
+    def add_pull(self, pull_data):
+        merged = pull_data.get('merged_at')
+        created = pull_data.get('created_at')
+
+        if merged:
+            merged_week = parser.parse(merged).date() + relativedelta.relativedelta(weekday=self._relative_day(-1))
+            if merged_week not in self._weekly_pulls:
+                self._weekly_pulls[merged_week] = {
+                    'merged': 0,
+                    'created': 0
+                }
+            self._weekly_pulls[merged_week]['merged'] += 1
+
+        if created:
+            created_week = parser.parse(created).date() + relativedelta.relativedelta(weekday=self._relative_day(-1))
+
+            if created_week not in self._weekly_pulls:
+                self._weekly_pulls[created_week] = {
+                    'merged': 0,
+                    'created': 0
+                }
+            self._weekly_pulls[created_week]['created'] += 1
+
+    def __str__(self):
+        rep = ""
+        for week_of in sorted(self._weekly_pulls.keys(), reverse=True):
+            pull_stats = self._weekly_pulls[week_of]
+            rep += "Week of %s... Created: %s, Merged: %s\n" % (week_of, pull_stats['created'], pull_stats['merged'])
+
+        return rep
+
+
+def org_pull_requests_week_over_week(org_name):
+    pulls = org_pull_requests_list(org_name)
+    sorted_by_creation = sorted(pulls, key=lambda pr_data: pr_data['created_at'], reverse=True)
+    earliest = parser.parse(sorted_by_creation[-1]['created_at'])
+    now = datetime.datetime.now(tz=pytz.UTC)
+
+    print("Weekly Pull Request summary for %s organization" % org_name)
+    print("------------")
+    print("Total PRs (open+closed+draft): %s" % len(pulls))
+    print("Full date range: %s through %s" % (earliest.date(), now.date()))
+    print("------------")
+
+    weekly_pulls = WeeklyPulls()
+    for pull in pulls:
+        weekly_pulls.add_pull(pull)
+
+    print(weekly_pulls)
+
+
+org_pull_requests_week_over_week('ramda')

--- a/pullrx/mr/collections.py
+++ b/pullrx/mr/collections.py
@@ -34,6 +34,7 @@ def collect_dict_keys(keys, *dicts, require_keys=True, flatten=True):
                     collected.append(value)
     return collected
 
+
 def filter_dict(dict_to_filer, predicate):
     filtered = {}
     for k, v in dict_to_filer:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 certifi==2019.11.28
 chardet==3.0.4
 idna==2.9
+python-dateutil==2.8.1
+pytz==2019.3
 requests==2.23.0
+six==1.14.0
 urllib3==1.25.8


### PR DESCRIPTION
Hacking in the pullrx.cmd.pull_requests playground module to calculate
pull requests by week and also support to cache pull data so it
doesn't need to be grabbed from github each time.